### PR TITLE
Remove input string from each node and node number & replace with offset start and end numbers and child_id.

### DIFF
--- a/remote-view/shared/src/main/scala/parsley/debug/RemoteView.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/RemoteView.scala
@@ -39,7 +39,7 @@ sealed trait RemoteView extends DebugView.Reusable {
   private [debug] final val ResponseTimeout: FiniteDuration = 10.second
 
   // Endpoint for post request
-  private [debug] final lazy val endPoint: Uri = uri"http://$address:$port/api/remote"
+  private [debug] final lazy val endPoint: Uri = uri"http://$address:$port/api/remote/tree"
 
   /**
    * Send the debug tree and input to the port and address specified in the 

--- a/remote-view/shared/src/main/scala/parsley/debug/RemoteView.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/RemoteView.scala
@@ -5,15 +5,15 @@
  */
 package parsley.debug
 
-import parsley.debug.internal.DebugTreeSerialiser
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 import sttp.client3.*
 import sttp.model.Uri
 
-import scala.concurrent.duration.*
-import scala.util.Try
-import scala.util.Failure
-import scala.util.Success
+import parsley.debug.internal.DebugTreeSerialiser
 
 /** The RemoteView HTTP module allows the parsley debug tree to be passed off to a server through a specified port on
   * local host (by default) or to a specified IP address. This enables all of the debug tree parsing, serving and 

--- a/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
@@ -37,7 +37,7 @@ import parsley.debug.ParseAttempt
   * @param input The input string passed to the parser.
   * @param children An array of child nodes.
   */
-private case class SerialisableDebugTree(name: String, internal: String, success: Boolean, child_id: Long, from_offset: ParseAttempt.Offset, to_offset: ParseAttempt.Offset, children: List[SerialisableDebugTree])
+private case class SerialisableDebugTree(name: String, internal: String, success: Boolean, childId: Long, fromOffset: ParseAttempt.Offset, toOffset: ParseAttempt.Offset, children: List[SerialisableDebugTree])
 
 private object SerialisableDebugTree {
   implicit val rw: RW[SerialisableDebugTree] = macroRW

--- a/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
@@ -5,11 +5,11 @@
  */
 package parsley.debug.internal
 
-import parsley.debug.DebugTree
-
 import java.io.Writer
 
 import upickle.default.{ReadWriter => RW, macroRW}
+
+import parsley.debug.DebugTree
 import parsley.debug.ParseAttempt
 
 /**

--- a/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
@@ -21,9 +21,9 @@ import parsley.debug.ParseAttempt
   *   name        : String
   *   internal    : String
   *   success     : Boolean
-  *   child_id    : Long
-  *   from_offset : Int
-  *   to_offset   : Int
+  *   childId    : Long
+  *   fromOffset : Int
+  *   toOffset   : Int
   *   input       : String
   *   children    : [DebugTree]
   * }
@@ -31,9 +31,9 @@ import parsley.debug.ParseAttempt
   * @param name (Possibly) User defined name.
   * @param internal Internal parser name.
   * @param success Did the parser succeed.
-  * @param child_id The unique child number of this node.
-  * @param from_offset Offset into the input in which this node's parse attempt starts.
-  * @param to_offset Offset into the input in which this node's parse attempt finished.
+  * @param childId The unique child number of this node.
+  * @param fromOffset Offset into the input in which this node's parse attempt starts.
+  * @param toOffset Offset into the input in which this node's parse attempt finished.
   * @param input The input string passed to the parser.
   * @param children An array of child nodes.
   */

--- a/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
@@ -43,7 +43,7 @@ private object SerialisableDebugTree {
   implicit val rw: RW[SerialisableDebugTree] = macroRW
 }
 
-private case class SerialisablePayload(input: String, tree: SerialisableDebugTree)
+private case class SerialisablePayload(input: String, root: SerialisableDebugTree)
 
 private object SerialisablePayload {
   implicit val rw: RW[SerialisablePayload] = macroRW


### PR DESCRIPTION
Number in the original representation meant child id so that change is just a better naming scheme.