### PR TITLE
Added isIterative property to DebugTreeSerialiser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val Java17 = JavaSpec.temurin("17")
 val Java21 = JavaSpec.temurin("21")
 
 val mainBranch = "master"
-val baseParsleyVersion = "5.0.0-M12"
+val baseParsleyVersion = "5.0-102bdaa-SNAPSHOT"
 val circeVersion = "0.14.10"
 val scalatestVersion = "3.2.19"
 // Here's hoping the stable version of Http4S works fine!

--- a/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
@@ -18,14 +18,15 @@ import parsley.debug.ParseAttempt
   * This will be serialised to JSON structures of the following form.
   * 
   * {
-  *   name        : String
-  *   internal    : String
-  *   success     : Boolean
-  *   childId    : Long
-  *   fromOffset : Int
-  *   toOffset   : Int
-  *   input       : String
-  *   children    : [DebugTree]
+  *   name            : String
+  *   internal        : String
+  *   success         : Boolean
+  *   childId         : Long
+  *   fromOffset      : Int
+  *   toOffset        : Int
+  *   input           : String
+  *   children        : [DebugTree]
+  *   doesNeedBubbling: Boolean
   * }
   *
   * @param name (Possibly) User defined name.
@@ -36,8 +37,9 @@ import parsley.debug.ParseAttempt
   * @param toOffset Offset into the input in which this node's parse attempt finished.
   * @param input The input string passed to the parser.
   * @param children An array of child nodes.
+  * @param doesNeedBubbling Does this node need to bubble up to the parent?
   */
-private case class SerialisableDebugTree(name: String, internal: String, success: Boolean, childId: Long, fromOffset: ParseAttempt.Offset, toOffset: ParseAttempt.Offset, children: List[SerialisableDebugTree])
+private case class SerialisableDebugTree(name: String, internal: String, success: Boolean, childId: Long, fromOffset: ParseAttempt.Offset, toOffset: ParseAttempt.Offset, children: List[SerialisableDebugTree], doesNeedBubbling: Boolean)
 
 private object SerialisableDebugTree {
   implicit val rw: RW[SerialisableDebugTree] = macroRW
@@ -63,7 +65,8 @@ object DebugTreeSerialiser {
       tree.childNumber.getOrElse(-1), 
       tree.parseResults.map(_.fromOffset).getOrElse(-1),
       tree.parseResults.map(_.toOffset).getOrElse(-1),
-      children
+      children,
+      tree.doesNeedBubbling
     )
   }
 

--- a/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
+++ b/remote-view/shared/src/main/scala/parsley/debug/internal/DebugTreeSerialiser.scala
@@ -18,15 +18,15 @@ import parsley.debug.ParseAttempt
   * This will be serialised to JSON structures of the following form.
   * 
   * {
-  *   name            : String
-  *   internal        : String
-  *   success         : Boolean
-  *   childId         : Long
-  *   fromOffset      : Int
-  *   toOffset        : Int
-  *   input           : String
-  *   children        : [DebugTree]
-  *   doesNeedBubbling: Boolean
+  *   name        : String
+  *   internal    : String
+  *   success     : Boolean
+  *   childId     : Long
+  *   fromOffset  : Int
+  *   toOffset    : Int
+  *   input       : String
+  *   children    : [DebugTree]
+  *   isIterative : Boolean
   * }
   *
   * @param name (Possibly) User defined name.
@@ -37,9 +37,9 @@ import parsley.debug.ParseAttempt
   * @param toOffset Offset into the input in which this node's parse attempt finished.
   * @param input The input string passed to the parser.
   * @param children An array of child nodes.
-  * @param doesNeedBubbling Does this node need to bubble up to the parent?
+  * @param isIterative Is this parser iterative (and opaque)?
   */
-private case class SerialisableDebugTree(name: String, internal: String, success: Boolean, childId: Long, fromOffset: ParseAttempt.Offset, toOffset: ParseAttempt.Offset, children: List[SerialisableDebugTree], doesNeedBubbling: Boolean)
+private case class SerialisableDebugTree(name: String, internal: String, success: Boolean, childId: Long, fromOffset: ParseAttempt.Offset, toOffset: ParseAttempt.Offset, children: List[SerialisableDebugTree], isIterative: Boolean)
 
 private object SerialisableDebugTree {
   implicit val rw: RW[SerialisableDebugTree] = macroRW
@@ -66,7 +66,7 @@ object DebugTreeSerialiser {
       tree.parseResults.map(_.fromOffset).getOrElse(-1),
       tree.parseResults.map(_.toOffset).getOrElse(-1),
       children,
-      tree.doesNeedBubbling
+      tree.isIterative
     )
   }
 


### PR DESCRIPTION
This follows a change to the Parsley Debug codebase wherein iterative combinators are recursively tagged; if a combinator tree node is iterative and transparent, then we bubble up to the first opaque parent within the debugger.